### PR TITLE
Jdp200501 30

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/entity/DeliveryAddress.java
+++ b/src/main/java/com/kodilla/ecommercee/entity/DeliveryAddress.java
@@ -3,10 +3,11 @@ package com.kodilla.ecommercee.entity;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "DELIVERYADDRESS")
@@ -18,9 +19,36 @@ public class DeliveryAddress {
     @Id
     @NotNull
     @GeneratedValue
-    private Long addressId;
+    private Long deliveryAddressId;
 
     @NotNull
-    private String address;
+    private String name;
+
+    @NotNull
+    private String country;
+
+    @NotNull
+    private String city;
+
+    @NotNull
+    private String street;
+
+    @NotNull
+    private String buildingNumber;
+
+    private int flatNumber;
+
+    @NotNull
+    private String postcode;
+
+    @NotNull
+    private int phone;
+
+    @OneToMany (
+            mappedBy = "deliveryAddress",
+            targetEntity = Order.class,
+            fetch = FetchType.EAGER
+    )
+    private List<Order> orders = new ArrayList<>();
 
 }

--- a/src/main/java/com/kodilla/ecommercee/entity/DeliveryAddress.java
+++ b/src/main/java/com/kodilla/ecommercee/entity/DeliveryAddress.java
@@ -47,7 +47,8 @@ public class DeliveryAddress {
     @OneToMany (
             mappedBy = "deliveryAddress",
             targetEntity = Order.class,
-            fetch = FetchType.EAGER
+            fetch = FetchType.EAGER,
+            cascade = CascadeType.MERGE
     )
     private List<Order> orders = new ArrayList<>();
 

--- a/src/main/java/com/kodilla/ecommercee/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/kodilla/ecommercee/repository/DeliveryAddressRepository.java
@@ -1,0 +1,13 @@
+package com.kodilla.ecommercee.repository;
+
+import com.kodilla.ecommercee.entity.DeliveryAddress;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import javax.transaction.Transactional;
+
+@Transactional
+@Repository
+public interface DeliveryAddressRepository extends CrudRepository<DeliveryAddress, Long> {
+
+}


### PR DESCRIPTION
Długo zastanawiałem się nad kaskadowaniem (pomiędzy Order – DeliveryAddress) ale nadal nie jestem do końca pewien czy powinno ono w ogóle występować lub jaki typ kaskadowania wybrać.
Rozpatrywałem przypadki:
Kasując DeliveryAddress nie chcemy kasować Orderów.
Kasując Order nie chcemy kasować DeliveryAddress'ów.
--> więc CascadeType.ALL i REMOVE odpada.

Nowy DeliveryAddress nie musi mieć żadnych Orderów. 
Nowy Order musi mieć jeden DeliveryAddress.
Zatem tworząc i zapisując nowy Order:
 - dodaję DeliveryAddres do nowego Ordera,
 - dodaję nowy Order do listy orders w danym DeliveryAddresie. Ta zmiana powinna zostać zapisana w danym DeliveryAddress. Czyli ostatecznie, wydaje mi się, że potrzebne jest CascadeType.MERGE.

Będę wdzięczny za potwierdzenie lub wyjaśnienie dlaczego powinno być inaczej.
Jeśli jest błąd to mam nadzieję, że testy go wykażą.